### PR TITLE
Changed python-version to 3.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install packages
         run: |


### PR DESCRIPTION
## Summary
Changed `python-version` to 3.8 in release action, because MetricFlow is not compatible with Python 3.7.

